### PR TITLE
Fix issue where `null` values are treated as empty strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+composer.lock
+vendor
+bin
 test.php
 .idea
 index.php

--- a/src/Core/TypeBuilder.php
+++ b/src/Core/TypeBuilder.php
@@ -63,16 +63,18 @@ abstract class TypeBuilder
         $str = '';
 
         if (is_int($string) || is_float($string)) {
-            $str .= $string . ',';
+            $str .= $string;
         } elseif (is_bool($string)) {
-            $str .= $string ? 'true,' : 'false,';
+            $str .= $string ? 'true' : 'false';
         } elseif (is_object($string) && is_subclass_of($string, FieldType::class)) {
-            $str .= $string->getValue() . ',';
+            $str .= $string->getValue();
+        } elseif (is_null($string)) {
+            $str .= 'null';
         } else {
-            $str .= '"' . $string . '",';
+            $str .= '"' . $string . '"';
         }
 
-        return $str;
+        return $str . ',';
     }
 
     private function disArraySelect($array)


### PR DESCRIPTION
When making a migration request, you might encounter an issue when trying to set a numerical fields to NULL.

This is because by default the package will turn `null` values into `""` (empty string), which is considered to be a value of type string by GraphQL.

This PR fix this issue by making NULL fields to be NULL in the generated Query.

Given the following payload : 
```php
$mutation = new Mutation('my_query');

$mutation->addArguments([
    'objects' => [
        'firstname' => 'John', 
        'lastname' => 'Cena',
        'birth_year' => null,
    ],
]);
```
 

Before : 
```graphql
mutation {
  my_query(
    objects: {
        firstname: "John", 
        lastname: "Cena",
        birth_year: ""
    }
  ) {
    returning {
      id
    }
  }
}

// error: invalid input syntax for type numeric: ""
```

After : 
```graphql
mutation {
  my_query(
    objects: {
        firstname: "John", 
        lastname: "Cena",
        birth_year: null
    }
  ) {
    returning {
      id
    }
  }
}
```