### PR TITLE
Better duplicate check

### DIFF
--- a/src/Core/TypeBuilder.php
+++ b/src/Core/TypeBuilder.php
@@ -138,8 +138,9 @@ abstract class TypeBuilder
     protected function isDuplicate($field, $index = null)
     {
         foreach ($this->getSelect() as $itemIndex => $item) {
+            $indexCheck = !is_null($index) && is_array($field);
 
-            if (((!is_null($index) && $index === $itemIndex) || is_null($index)) && $item === $field) {
+            if ((($indexCheck && $index === $itemIndex) || !$indexCheck) && $item === $field) {
                 return true;
             }
         }

--- a/src/Core/TypeBuilder.php
+++ b/src/Core/TypeBuilder.php
@@ -132,12 +132,14 @@ abstract class TypeBuilder
 
     /**
      * @param $field
+     * @param mixed $index
      * @return bool
      */
-    protected function isDuplicate($field)
+    protected function isDuplicate($field, $index = null)
     {
-        foreach ($this->getSelect() as $item) {
-            if ($item === $field) {
+        foreach ($this->getSelect() as $itemIndex => $item) {
+
+            if (((!is_null($index) && $index === $itemIndex) || is_null($index)) && $item === $field) {
                 return true;
             }
         }

--- a/src/Types/Mutation.php
+++ b/src/Types/Mutation.php
@@ -36,7 +36,7 @@ class Mutation extends TypeBuilder implements Type
     {
         if (is_array($field)) {
             foreach ($field as $index => $item) {
-                if (!$this->isDuplicate($item)) {
+                if (!$this->isDuplicate($item, $index)) {
                     $this->select[$index] = $item;
                 }
             }

--- a/src/Types/Query.php
+++ b/src/Types/Query.php
@@ -36,7 +36,7 @@ class Query extends TypeBuilder implements Type
     {
         if (is_array($field)) {
             foreach ($field as $index => $item) {
-                if (!$this->isDuplicate($item)) {
+                if (!$this->isDuplicate($item, $index)) {
                     $this->select[$index] = $item;
                 }
             }


### PR DESCRIPTION
Implement better duplicate check by also accounting the index. For example if your select has currentPrice and totalPrice with the value of ["amount"], one would be excluded in the current duplicate check.